### PR TITLE
Share gvfsd p2p sockets

### DIFF
--- a/com.github.calo001.fondo.json
+++ b/com.github.calo001.fondo.json
@@ -1,9 +1,9 @@
 {
     "app-id": "com.github.calo001.fondo",
     "base": "io.elementary.BaseApp",
-    "base-version": "juno-19.08",
+    "base-version": "juno-20.08",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.36",
+    "runtime-version": "3.38",
     "sdk": "org.gnome.Sdk",
     "command": "com.github.calo001.fondo",
     "finish-args": [

--- a/com.github.calo001.fondo.json
+++ b/com.github.calo001.fondo.json
@@ -15,6 +15,7 @@
         "--talk-name=org.gtk.vfs.*",
         "--talk-name=org.gnome.SessionManager",
         "--filesystem=xdg-run/dconf",
+        "--filesystem=xdg-run/gvfsd",
         "--talk-name=org.freedesktop.FileManager1",
         "--filesystem=host",
         "--filesystem=~/.config/dconf:ro",


### PR DESCRIPTION
See https://gitlab.gnome.org/GNOME/gvfs/-/issues/515.

This allows Fondo to set wallpapers once again on (at least) Fedora 34.

Fixes https://github.com/calo001/fondo/issues/141, though using the wallpaper portal would be preferable.
